### PR TITLE
Update for ESP RTOS v3.2 era.

### DIFF
--- a/src/NeoPixelBus.h
+++ b/src/NeoPixelBus.h
@@ -85,7 +85,7 @@ License along with NeoPixel.  If not, see
 #include "internal/NeoAvrMethod.h"
 #include "internal/DotStarAvrMethod.h"
 
-#elif defined(CONFIG_TARGET_PLATFORM_ESP8266)
+#elif defined(CONFIG_TARGET_PLATFORM_ESP8266) || defined(CONFIG_IDF_TARGET_ESP8266)
 
 #include "internal/NeoEsp8266RtosDmaMethod.h"
 

--- a/src/internal/NeoEsp8266RtosDmaMethod.h
+++ b/src/internal/NeoEsp8266RtosDmaMethod.h
@@ -25,7 +25,7 @@ License along with NeoPixel.  If not, see
 
 #pragma once
 
-#ifdef CONFIG_TARGET_PLATFORM_ESP8266
+#if defined(CONFIG_TARGET_PLATFORM_ESP8266) || defined(CONFIG_IDF_TARGET_ESP8266)
 
 #include <esp_attr.h>
 #include <driver/gpio.h>


### PR DESCRIPTION
As part of the unification of the esp32 IDF and the esp8266 rtos sdk,
the definitions available have changed.  Add the new ones to make this
work out of the box.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>